### PR TITLE
Add partition key to order by clause

### DIFF
--- a/CopyInfo.cs
+++ b/CopyInfo.cs
@@ -38,7 +38,7 @@ namespace SmartBulkCopy
         }
         public string GetOrderBy()
         {           
-            return SourceTableInfo.PrimaryIndex.GetOrderBy(excludePartitionColumn:true);
+            return SourceTableInfo.PrimaryIndex.GetOrderBy(excludePartitionColumn:false);
         }
     }
 


### PR DESCRIPTION
When the partition key is not present in the orderby clause, there is a mismatch between the sort order of the source selection and the bulk copy operation causing the exception Cannot bulk load. The bulk data stream was incorrectly specified as sorted or the data violates a uniqueness constraint imposed by the target table. Sort order incorrect for the following ..