### PR TITLE
Feature: Add the possibility to pass the entire configuration as a st…

### DIFF
--- a/client/Program.cs
+++ b/client/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using NLog;
+using System.IO;
 
 namespace SmartBulkCopy
 {
@@ -18,11 +19,24 @@ namespace SmartBulkCopy
             try
             {
                 SmartBulkCopyConfiguration bulkCopyConfig;
+
                 if (args.Length > 0)
-                    bulkCopyConfig = SmartBulkCopyConfiguration.LoadFromConfigFile(args[0], logger);
-                else 
+                {
+                    if (args[0].StartsWith("{"))
+                    {
+                        SmartBulkCopyConfiguration.PersistConfigurationToFile(args[0]);
+                        bulkCopyConfig = SmartBulkCopyConfiguration.LoadFromConfigFile(logger);
+                    }
+                    else
+                    {
+                        bulkCopyConfig = SmartBulkCopyConfiguration.LoadFromConfigFile(args[0], logger);
+                    }
+                }
+                else
+                {
                     bulkCopyConfig = SmartBulkCopyConfiguration.LoadFromConfigFile(logger);
-                
+                }
+
                 var sbc = new SmartBulkCopy(bulkCopyConfig, logger);
                 result = await sbc.Copy();
             }

--- a/client/SmartBulkCopyConfig.cs
+++ b/client/SmartBulkCopyConfig.cs
@@ -114,6 +114,11 @@ namespace SmartBulkCopy
 
         public static SmartBulkCopyConfiguration EmptyConfiguration => new SmartBulkCopyConfiguration();
 
+        public static void PersistConfigurationToFile(string configuration)
+        {
+            File.WriteAllText(Path.Combine(Directory.GetCurrentDirectory(), "smartbulkcopy.config.json"), configuration, new System.Text.UTF8Encoding(false));
+        }
+
         public static SmartBulkCopyConfiguration LoadFromConfigFile(ILogger logger)        
         {
             return LoadFromConfigFile("smartbulkcopy.config", logger);

--- a/tests/Configuration.cs
+++ b/tests/Configuration.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System;
 using DotNetEnv;
+using System.IO;
 
 namespace SmartBulkCopy.Tests
 {
@@ -40,6 +41,18 @@ namespace SmartBulkCopy.Tests
         public void DontStopIfTemporalTable()
         {
             Assert.IsFalse(_config.StopIf.HasFlag(StopIf.TemporalTable));
+        }
+
+        [Test]
+        public void PersistConfigurationToFile()
+        {
+            string configuration = System.IO.File.ReadAllText(Path.Combine(Directory.GetCurrentDirectory(), "smartbulkcopy.config.test.json"));
+            SmartBulkCopyConfiguration.PersistConfigurationToFile(configuration);
+
+            Assert.That(Path.Combine(Directory.GetCurrentDirectory(), "smartbulkcopy.config.json"), Does.Exist);
+            SmartBulkCopyConfiguration config = SmartBulkCopyConfiguration.LoadFromConfigFile(_logger);
+            
+            Assert.AreEqual(System.Text.Json.JsonSerializer.Serialize(_config), System.Text.Json.JsonSerializer.Serialize(config));
         }
     }
 }


### PR DESCRIPTION
…ring paramenter

As promised, a PR that enables the user to pass the entire configuration as an argument, instead of having to work with files. We learned that Azure ACI and fileshares didn't behave as expected.

The configuration has to a json oneliner, with escaped double quotes.
```
{\"source\":{\"connection-string\":\"Server=;Initial Catalog=;Connection Timeout=300;\"},\"destination\":{\"connection-string\":\"Server=;Initial Catalog=;Connection Timeout=90;\"},\"tables\":{\"include\":[\"*\"],\"exclude\":[]},\"options\":{\"command-timeout\":1800,\"tasks\":8,\"logical-partitions\":\"auto\",\"batch-size\":100000,\"truncate-tables\":true,\"sync-identity\":false,\"safe-check\":\"readonly\",\"stop-if\":{\"secondary-indexes\":true,\"temporal-table\":true},\"retry-connection\":{\"delay-increment\":10,\"max-attempt\":5}}}
```

And to pass it correctly, it should look like this:
```
SmartBulkCopy.exe "{\"source\":{\"connection-string\":\"Server=;Initial Catalog=;Connection Timeout=300;\"},\"destination\":{\"connection-string\":\"Server=;Initial Catalog=;Connection Timeout=90;\"},\"tables\":{\"include\":[\"*\"],\"exclude\":[]},\"options\":{\"command-timeout\":1800,\"tasks\":8,\"logical-partitions\":\"auto\",\"batch-size\":100000,\"truncate-tables\":true,\"sync-identity\":false,\"safe-check\":\"readonly\",\"stop-if\":{\"secondary-indexes\":true,\"temporal-table\":true},\"retry-connection\":{\"delay-increment\":10,\"max-attempt\":5}}}"
```

The unit test simply takes the current template, persists it to disk and compares the 2 config objects, based on a json deserializer, as the objects are simple in structure.